### PR TITLE
chore: format pass and lint CI leg

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             otp: "26.2.5"
           - elixir: "1.18.4"
             otp: "26.2.5"
+            lint: lint
     steps:
       - uses: actions/checkout@v7
       - name: Set up Elixir
@@ -45,6 +46,9 @@ jobs:
         run: mix deps.get
       - name: Compile dependencies
         run: mix deps.compile
+      - name: Ensure files are formatted
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
       - name: Build package
         run: mix hex.build
       - name: Run tests

--- a/lib/arke_auth/boundary/otp_manager.ex
+++ b/lib/arke_auth/boundary/otp_manager.ex
@@ -20,21 +20,40 @@ defmodule ArkeAuth.Boundary.OtpManager do
 
   manager_id(:otp)
 
-  def get_code(project, member,action \\ "signin")
-  def get_code(project, member,action) when is_atom(action), do: get_code(project, member,to_string(action))
-  def get_code(project, member,action) do
+  def get_code(project, member, action \\ "signin")
+
+  def get_code(project, member, action) when is_atom(action),
+    do: get_code(project, member, to_string(action))
+
+  def get_code(project, member, action) do
     case System.get_env("OTP_BYPASS_CODE") do
-      nil -> get_member_code(project,member,action)
-      "" ->  get_member_code(project,member,action)
-      value -> %{data: %{code: value, expiry_datetime: NaiveDateTime.utc_now() |> NaiveDateTime.add(300, :second) }}
+      nil ->
+        get_member_code(project, member, action)
+
+      "" ->
+        get_member_code(project, member, action)
+
+      value ->
+        %{
+          data: %{
+            code: value,
+            expiry_datetime: NaiveDateTime.utc_now() |> NaiveDateTime.add(300, :second)
+          }
+        }
     end
   end
 
-  defp get_member_code(project,member,action) do
-    QueryManager.get_by(project: project,arke: "otp",id: Otp.parse_otp_id(action, member.id),action: action)
+  defp get_member_code(project, member, action) do
+    QueryManager.get_by(
+      project: project,
+      arke: "otp",
+      id: Otp.parse_otp_id(action, member.id),
+      action: action
+    )
   end
 
-  def delete_otp(%Arke.Core.Unit{metadata: %{project: project}}=unit), do:   QueryManager.delete(project, unit)
-  def delete_otp(_unit), do:  nil
+  def delete_otp(%Arke.Core.Unit{metadata: %{project: project}} = unit),
+    do: QueryManager.delete(project, unit)
 
+  def delete_otp(_unit), do: nil
 end

--- a/lib/arke_auth/boundary/validators.ex
+++ b/lib/arke_auth/boundary/validators.ex
@@ -14,8 +14,8 @@
 
 defmodule ArkeAuth.Boundary.Validators do
   @moduledoc """
-             Module to manage all the validatos for `ArkeAuth`
-             """
+  Module to manage all the validatos for `ArkeAuth`
+  """
   alias Arke.Utils.ErrorGenerator, as: Error
 
   ######################################################################################################################

--- a/lib/arke_auth/core/member.ex
+++ b/lib/arke_auth/core/member.ex
@@ -25,46 +25,55 @@ defmodule ArkeAuth.Core.Member do
   group id: "arke_auth_member" do
   end
 
-
-
   def on_unit_load(arke, data, _persistence_fn), do: {:ok, data}
   def before_unit_load(_arke, data, _persistence_fn), do: {:ok, data}
   def on_unit_validate(_arke, unit), do: {:ok, unit}
 
-  #TODO Handle user validation (if user exists)
-  def before_unit_validate(_arke, %{data: %{arke_system_user: arke_system_user}}=unit) when is_binary(arke_system_user) do
+  # TODO Handle user validation (if user exists)
+  def before_unit_validate(_arke, %{data: %{arke_system_user: arke_system_user}} = unit)
+      when is_binary(arke_system_user) do
     {:ok, unit}
   end
-  #TODO Handle user validation (if user already exists and user data validation)
-  def before_unit_validate(_arke, %{data: %{arke_system_user: arke_system_user}}=unit) when is_map(arke_system_user) do
+
+  # TODO Handle user validation (if user already exists and user data validation)
+  def before_unit_validate(_arke, %{data: %{arke_system_user: arke_system_user}} = unit)
+      when is_map(arke_system_user) do
     {:ok, unit}
   end
 
   def on_unit_create(_arke, unit), do: {:ok, unit}
 
-  def before_unit_create(_arke, %{data: %{arke_system_user: arke_system_user}}=unit) when is_map(arke_system_user) do
-
+  def before_unit_create(_arke, %{data: %{arke_system_user: arke_system_user}} = unit)
+      when is_map(arke_system_user) do
     arke_user = ArkeManager.get(:user, :arke_system)
 
-    user_data = Enum.map(arke_system_user, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    user_data =
+      Enum.map(arke_system_user, fn {key, value} -> {String.to_existing_atom(key), value} end)
+
     Arke.QueryManager.create(:arke_system, arke_user, user_data)
     |> case do
       {:ok, user} ->
         unit = Arke.Core.Unit.update(unit, arke_system_user: user.id)
         {:ok, unit}
+
       {:error, error} ->
         {:error, error}
     end
   end
+
   def before_unit_create(_arke, unit), do: {:ok, unit}
 
-  def before_unit_update(_arke, %{data: %{arke_system_user: arke_system_user}, metadata: %{project: project}}=unit) when is_map(arke_system_user) do
-
+  def before_unit_update(
+        _arke,
+        %{data: %{arke_system_user: arke_system_user}, metadata: %{project: project}} = unit
+      )
+      when is_map(arke_system_user) do
     arke_user = ArkeManager.get(:user, :arke_system)
 
-    user_data = Enum.map(arke_system_user, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    user_data =
+      Enum.map(arke_system_user, fn {key, value} -> {String.to_existing_atom(key), value} end)
 
-    #TODO handle without rendundant query
+    # TODO handle without rendundant query
     old_member = QueryManager.get_by(project: project, id: Atom.to_string(unit.id))
     user = QueryManager.get_by(project: :arke_system, id: old_member.data.arke_system_user)
 
@@ -73,30 +82,50 @@ defmodule ArkeAuth.Core.Member do
       {:ok, user} ->
         unit = Arke.Core.Unit.update(unit, arke_system_user: user.id)
         {:ok, unit}
+
       {:error, error} ->
         {:error, error}
     end
   end
+
   def before_unit_update(_arke, unit), do: {:ok, unit}
 
   def on_unit_delete(_arke, unit) do
-    user = QueryManager.get_by(project: :arke_system, arke_id: :user, id: unit.data.arke_system_user)
+    user =
+      QueryManager.get_by(project: :arke_system, arke_id: :user, id: unit.data.arke_system_user)
+
     QueryManager.delete(:arke_system, user)
     {:ok, unit}
   end
+
   def before_unit_delete(_arke, unit), do: {:ok, unit}
 
-  defp handle_get_permission(member, %{metadata: %{project: project}}=arke) do
+  defp handle_get_permission(member, %{metadata: %{project: project}} = arke) do
     arke_link = ArkeManager.get(:arke_link, :arke_system)
-    arke_member_public = QueryManager.get_by(project: project, arke_id: "ake", id: "member_public")
-    parent_id_list = get_parent_list(member)
-    permissions = QueryManager.query(project: project, arke: arke_link.id) |> QueryManager.where(parent_id__in: parent_id_list, child_id: Atom.to_string(arke.id), type: "permission") |> QueryManager.all
-    member_public_permission =get_permission_dict(permissions,true)
-    member_permission = get_permission_dict(permissions,false)
 
-    data = Map.merge(member_public_permission, member_permission, fn _k, v1, v2 ->
-      if v1, do: v1, else: v2
-    end) |> permission_dict
+    arke_member_public =
+      QueryManager.get_by(project: project, arke_id: "ake", id: "member_public")
+
+    parent_id_list = get_parent_list(member)
+
+    permissions =
+      QueryManager.query(project: project, arke: arke_link.id)
+      |> QueryManager.where(
+        parent_id__in: parent_id_list,
+        child_id: Atom.to_string(arke.id),
+        type: "permission"
+      )
+      |> QueryManager.all()
+
+    member_public_permission = get_permission_dict(permissions, true)
+    member_permission = get_permission_dict(permissions, false)
+
+    data =
+      Map.merge(member_public_permission, member_permission, fn _k, v1, v2 ->
+        if v1, do: v1, else: v2
+      end)
+      |> permission_dict
+
     if Map.to_list(data) == [] do
       {:error, nil}
     else
@@ -116,15 +145,22 @@ defmodule ArkeAuth.Core.Member do
 
     %{filter: filter, get: get, put: put, delete: delete, post: post, child_only: child_only}
   end
+
   defp get_permission_dict(permission_list, is_public \\ false) do
-    cond = if is_public, do: fn parent_id -> parent_id == "member_public" end, else: fn parent_id -> parent_id != "member_public" end
+    cond =
+      if is_public,
+        do: fn parent_id -> parent_id == "member_public" end,
+        else: fn parent_id -> parent_id != "member_public" end
+
     case Enum.find(permission_list, fn p -> cond.(p.parent_id) end) do
-      nil -> permission_dict()
+      nil ->
+        permission_dict()
+
       u ->
         permission_dict(u.metadata)
+    end
   end
-  end
+
   defp get_parent_list(nil), do: ["member_public"]
   defp get_parent_list(member), do: ["member_public", to_string(member.arke_id)]
-
 end

--- a/lib/arke_auth/core/temporary_token.ex
+++ b/lib/arke_auth/core/temporary_token.ex
@@ -14,12 +14,11 @@
 
 defmodule ArkeAuth.Core.TemporaryToken do
   @moduledoc """
-             Documentation for `TemporaryToken`.
-             """
+  Documentation for `TemporaryToken`.
+  """
 
   alias Arke.QueryManager
   alias Arke.Boundary.ArkeManager
-
 
   use Arke.System
 
@@ -34,21 +33,38 @@ defmodule ArkeAuth.Core.TemporaryToken do
   end
 
   def generate_auth_token(project, member, duration \\ nil, is_reusable \\ false, opts \\ [])
-  def generate_auth_token(project, member, duration, is_reusable, opts) when is_map(member), do: generate_auth_token(project, member.id, duration, is_reusable, opts)
-  def generate_auth_token(project, member_id, duration, is_reusable, opts ) do
+
+  def generate_auth_token(project, member, duration, is_reusable, opts) when is_map(member),
+    do: generate_auth_token(project, member.id, duration, is_reusable, opts)
+
+  def generate_auth_token(project, member_id, duration, is_reusable, opts) do
     temp_arke = ArkeManager.get(:temporary_token, project)
     expiration_datetime = calculate_expiration_datetime(duration)
-    data = [link_member: member_id, expiration_datetime: expiration_datetime, is_reusable: is_reusable] ++ opts
+
+    data =
+      [link_member: member_id, expiration_datetime: expiration_datetime, is_reusable: is_reusable] ++
+        opts
+
     QueryManager.create(project, temp_arke, data)
   end
 
-  defp calculate_expiration_datetime(duration) when is_nil(duration), do: add_from_now(Application.get_env(:arke_auth, :temporary_token_expiration, 1800) |> to_string())
+  defp calculate_expiration_datetime(duration) when is_nil(duration),
+    do:
+      add_from_now(
+        Application.get_env(:arke_auth, :temporary_token_expiration, 1800)
+        |> to_string()
+      )
+
   defp calculate_expiration_datetime(%{days: days}), do: add_from_now(days * 86400)
   defp calculate_expiration_datetime(%{minutes: minutes}), do: add_from_now(minutes * 60)
-  defp calculate_expiration_datetime(%{days: days, minutes: minutes}), do: add_from_now(days * 86400 + minutes * 60)
+
+  defp calculate_expiration_datetime(%{days: days, minutes: minutes}),
+    do: add_from_now(days * 86400 + minutes * 60)
+
   defp calculate_expiration_datetime(duration), do: add_from_now(duration)
 
-  defp add_from_now(seconds) when is_binary(seconds), do: String.to_integer(seconds) |> add_from_now
+  defp add_from_now(seconds) when is_binary(seconds),
+    do: String.to_integer(seconds) |> add_from_now
+
   defp add_from_now(seconds), do: NaiveDateTime.utc_now() |> NaiveDateTime.add(seconds, :second)
 end
-

--- a/lib/arke_auth/core/user.ex
+++ b/lib/arke_auth/core/user.ex
@@ -30,7 +30,9 @@ defmodule ArkeAuth.Core.User do
     case Map.get(data, :arke_id) do
       nil ->
         with {:ok, pwd} <- Validators.check_user_password(data) do
-          new_data = Map.put(data, :password_hash, Bcrypt.hash_pwd_salt(pwd)) |> Map.delete(:password)
+          new_data =
+            Map.put(data, :password_hash, Bcrypt.hash_pwd_salt(pwd)) |> Map.delete(:password)
+
           {:ok, new_data}
         else
           {:error, msg} -> {:error, msg}

--- a/lib/arke_auth/sso_guardian.ex
+++ b/lib/arke_auth/sso_guardian.ex
@@ -14,8 +14,8 @@
 
 defmodule ArkeAuth.SSOGuardian do
   @moduledoc """
-             Guardian callbacks valid in a SSO process
-             """
+  Guardian callbacks valid in a SSO process
+  """
   use Guardian, otp_app: :arke_auth
 
   @doc """
@@ -23,8 +23,9 @@ defmodule ArkeAuth.SSOGuardian do
   """
   def subject_for_token(user, _claims) do
     jwt_data = %{
-      id: to_string(user.id),
+      id: to_string(user.id)
     }
+
     sub = Map.merge(jwt_data, Map.drop(user.data, [:password_hash]))
     {:ok, sub}
   end
@@ -38,10 +39,13 @@ defmodule ArkeAuth.SSOGuardian do
   """
   def resource_from_claims(claims) do
     id = claims["sub"]["id"]
+
     case Arke.QueryManager.get_by(project: :arke_system, arke_id: :user, id: id) do
-      nil -> {:error, :unauthorized}
+      nil ->
+        {:error, :unauthorized}
+
       user ->
-        data = Map.get(user,:data,%{})
+        data = Map.get(user, :data, %{})
         {:ok, user}
     end
   end


### PR DESCRIPTION
## Description

Adds the default `.formatter.exs`, the mechanical format pass, and a
`mix format --check-formatted` step in CI guarded by a `lint` flag on the 1.18.4
matrix leg.

## Docs
- [ ] I have updated the docs accordingly

## Test

- [ ] I have added tests that prove my fix is effective or that my feature works
