### PR TITLE
chore: clear compiler warnings and gate on them in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Ensure files are formatted
         run: mix format --check-formatted
         if: ${{ matrix.lint }}
+      - name: Compile without warnings
+        run: mix compile --force --warnings-as-errors
+        if: ${{ matrix.lint }}
       - name: Build package
         run: mix hex.build
       - name: Run tests

--- a/lib/arke_auth/core/member.ex
+++ b/lib/arke_auth/core/member.ex
@@ -14,7 +14,6 @@
 
 defmodule ArkeAuth.Core.Member do
   alias Arke.QueryManager
-  alias ArkeAuth.Core.Member
   alias Arke.Boundary.ArkeManager
 
   @moduledoc """
@@ -25,7 +24,7 @@ defmodule ArkeAuth.Core.Member do
   group id: "arke_auth_member" do
   end
 
-  def on_unit_load(arke, data, _persistence_fn), do: {:ok, data}
+  def on_unit_load(_arke, data, _persistence_fn), do: {:ok, data}
   def before_unit_load(_arke, data, _persistence_fn), do: {:ok, data}
   def on_unit_validate(_arke, unit), do: {:ok, unit}
 
@@ -68,7 +67,7 @@ defmodule ArkeAuth.Core.Member do
         %{data: %{arke_system_user: arke_system_user}, metadata: %{project: project}} = unit
       )
       when is_map(arke_system_user) do
-    arke_user = ArkeManager.get(:user, :arke_system)
+    _arke_user = ArkeManager.get(:user, :arke_system)
 
     user_data =
       Enum.map(arke_system_user, fn {key, value} -> {String.to_existing_atom(key), value} end)
@@ -99,68 +98,4 @@ defmodule ArkeAuth.Core.Member do
   end
 
   def before_unit_delete(_arke, unit), do: {:ok, unit}
-
-  defp handle_get_permission(member, %{metadata: %{project: project}} = arke) do
-    arke_link = ArkeManager.get(:arke_link, :arke_system)
-
-    arke_member_public =
-      QueryManager.get_by(project: project, arke_id: "ake", id: "member_public")
-
-    parent_id_list = get_parent_list(member)
-
-    permissions =
-      QueryManager.query(project: project, arke: arke_link.id)
-      |> QueryManager.where(
-        parent_id__in: parent_id_list,
-        child_id: Atom.to_string(arke.id),
-        type: "permission"
-      )
-      |> QueryManager.all()
-
-    member_public_permission = get_permission_dict(permissions, true)
-    member_permission = get_permission_dict(permissions, false)
-
-    data =
-      Map.merge(member_public_permission, member_permission, fn _k, v1, v2 ->
-        if v1, do: v1, else: v2
-      end)
-      |> permission_dict
-
-    if Map.to_list(data) == [] do
-      {:error, nil}
-    else
-      {:ok, data}
-    end
-  end
-
-  defp permission_dict(data \\ %{}) do
-    updated_data = for {key, val} <- data, into: %{}, do: {to_string(key), val}
-
-    filter = Map.get(updated_data, "filter", nil)
-    get = Map.get(updated_data, "get", false)
-    put = Map.get(updated_data, "put", false)
-    delete = Map.get(updated_data, "delete", false)
-    post = Map.get(updated_data, "post", false)
-    child_only = Map.get(updated_data, "child_only", false)
-
-    %{filter: filter, get: get, put: put, delete: delete, post: post, child_only: child_only}
-  end
-
-  defp get_permission_dict(permission_list, is_public \\ false) do
-    cond =
-      if is_public,
-        do: fn parent_id -> parent_id == "member_public" end,
-        else: fn parent_id -> parent_id != "member_public" end
-
-    case Enum.find(permission_list, fn p -> cond.(p.parent_id) end) do
-      nil ->
-        permission_dict()
-
-      u ->
-        permission_dict(u.metadata)
-    end
-  end
-
-  defp get_parent_list(nil), do: ["member_public"]
-  defp get_parent_list(member), do: ["member_public", to_string(member.arke_id)]
 end

--- a/lib/arke_auth/guardian.ex
+++ b/lib/arke_auth/guardian.ex
@@ -58,10 +58,6 @@ defmodule ArkeAuth.Guardian do
     {:ok, sub}
   end
 
-  def subject_for_token(_, _) do
-    {:error, :reason_for_error}
-  end
-
   @doc """
   Get from the token the resource
   """
@@ -76,10 +72,6 @@ defmodule ArkeAuth.Guardian do
       member ->
         check_member(member)
     end
-  end
-
-  def resource_from_claims(_claims) do
-    {:error, :reason_for_error}
   end
 
   def check_member(%{data: %{inactive: true}}), do: {:error, :unauthorized}

--- a/lib/arke_auth/sso_guardian.ex
+++ b/lib/arke_auth/sso_guardian.ex
@@ -45,7 +45,7 @@ defmodule ArkeAuth.SSOGuardian do
         {:error, :unauthorized}
 
       user ->
-        data = Map.get(user, :data, %{})
+        _data = Map.get(user, :data, %{})
         {:ok, user}
     end
   end

--- a/lib/arke_auth/sso_guardian.ex
+++ b/lib/arke_auth/sso_guardian.ex
@@ -30,10 +30,6 @@ defmodule ArkeAuth.SSOGuardian do
     {:ok, sub}
   end
 
-  def subject_for_token(_, _) do
-    {:error, :reason_for_error}
-  end
-
   @doc """
   Get from the token the resource
   """
@@ -48,9 +44,5 @@ defmodule ArkeAuth.SSOGuardian do
         _data = Map.get(user, :data, %{})
         {:ok, user}
     end
-  end
-
-  def resource_from_claims(_claims) do
-    {:error, :reason_for_error}
   end
 end

--- a/lib/arke_auth/utils/permission.ex
+++ b/lib/arke_auth/utils/permission.ex
@@ -16,8 +16,6 @@ defmodule ArkeAuth.Utils.Permission do
   alias Arke.QueryManager
   alias Arke.Boundary.ArkeManager
 
-  alias Arke.Utils.ErrorGenerator, as: Error
-
   def get_public_permission(%{metadata: %{project: project}} = arke),
     do: get_public_permission(to_string(arke.id), project)
 
@@ -31,7 +29,7 @@ defmodule ArkeAuth.Utils.Permission do
     do: get_member_permission(member, to_string(arke.id), project)
 
   def get_member_permission(%{impersonate: true} = member, arke_id, project) do
-    parent_list = get_parent_list(member)
+    _parent_list = get_parent_list(member)
     permissions = get_arke_permission(arke_id, project, member)
     member_public_permission = get_permission_dict(permissions, nil, true)
     member_permission = get_permission_dict(permissions, member, false)
@@ -56,7 +54,7 @@ defmodule ArkeAuth.Utils.Permission do
   end
 
   def get_member_permission(member, arke_id, project) do
-    parent_list = get_parent_list(member)
+    _parent_list = get_parent_list(member)
     permissions = get_arke_permission(arke_id, project, member)
     member_public_permission = get_permission_dict(permissions, nil, true)
     member_permission = get_permission_dict(permissions, member, false)
@@ -89,7 +87,7 @@ defmodule ArkeAuth.Utils.Permission do
     |> QueryManager.all()
   end
 
-  defp get_permission_dict(permission_list, member \\ nil, is_public \\ false) do
+  defp get_permission_dict(permission_list, member, is_public) do
     cond =
       if is_public,
         do: fn parent_id -> parent_id == "member_public" end,
@@ -107,12 +105,10 @@ defmodule ArkeAuth.Utils.Permission do
   defp get_parent_list(nil), do: ["member_public"]
   defp get_parent_list(member), do: ["member_public", to_string(member.arke_id)]
 
-  defp permission_dict(data, member \\ nil)
-
-  defp permission_dict(data, %{arke_id: :super_admin} = _member),
+  defp permission_dict(_data, %{arke_id: :super_admin} = _member),
     do: %{filter: nil, get: true, put: true, post: true, delete: true}
 
-  defp permission_dict(data, %{data: %{subscription_active: false}}),
+  defp permission_dict(_data, %{data: %{subscription_active: false}}),
     do: %{filter: nil, get: false, put: false, post: false, delete: false}
 
   defp permission_dict(data, _member) do

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule ArkeAuth.MixProject do
       deps: deps(),
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      elixirc_options: [warnings_as_errors: false, no_warn_undefined: @xref_exclude],
+      elixirc_options: [no_warn_undefined: @xref_exclude],
       versioning: versioning()
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,8 @@ defmodule ArkeAuth.MixProject do
   @scm_url "https://github.com/arkemis/arke-auth"
   @site_url "https://arkehub.com"
 
+  @xref_exclude [ArkeAuth.Guardian.Plug]
+
   def project do
     [
       app: :arke_auth,
@@ -22,7 +24,7 @@ defmodule ArkeAuth.MixProject do
       deps: deps(),
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      elixirc_options: [warnings_as_errors: false],
+      elixirc_options: [warnings_as_errors: false, no_warn_undefined: @xref_exclude],
       versioning: versioning()
     ]
   end


### PR DESCRIPTION
## Description

Clears the remaining compiler warnings and fails the lint leg on any new one.
Verified clean on both matrix legs, 1.16.3 and 1.18.4.

Not cosmetic:

- `member.ex` carried a stale duplicate of the permission chain
  (`handle_get_permission/2`, `get_parent_list/1`, `get_permission_dict/2`,
  `permission_dict/1`). The live one is in `utils/permission.ex` at different arities.
- The `{:error, :reason_for_error}` clauses of `subject_for_token/2` and
  `resource_from_claims/1` in both guardians were shadowed by a clause matching
  anything, so they never ran. Removed as dead code, behaviour unchanged. Note that
  malformed claims therefore raise rather than returning an error tuple.
- `ArkeAuth.Guardian.Plug` goes in `no_warn_undefined`: Guardian only generates it
  `if Code.ensure_loaded?(Plug)`, and plug is an optional dependency this package does
  not declare, so it is genuinely absent when arke-auth compiles alone.

The rest is mechanical.

## Docs
- [ ] I have updated the docs accordingly

## Test

- [ ] I have added tests that prove my fix is effective or that my feature works
